### PR TITLE
feat(database): Admin can promote attendant

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -121,6 +121,44 @@ def login():
         }), 400
 
 
+@blueprint.route('/admin/<user_id>', methods=['PUT'])
+@jwt_required
+def make_admin(user_id):
+    """
+    Function enables user to promote an existent user to admin
+
+    :returns:
+
+    Success message after successful update
+    """
+    username = get_jwt_identity()
+    user = Product.query('users', 'username', username)
+
+    if user[-1] is False:
+        return jsonify({
+            'message': 'You are not authorized to access this!'
+        }), 503
+    try:
+        user = Product.query('users', 'user_id', user_id)
+
+        if not user:
+            return jsonify({
+                'message': 'This user does not exist!'
+            }), 400
+        elif user[-1] is True:
+            return jsonify({
+                'message': 'This user is already admin!'
+            }), 400
+        Product.update('users', 'admin', 'true', 'user_id', user_id)
+        return jsonify({
+            'message': '{} has been promoted!'.format(user[1])
+        }), 201
+    except ValueError:
+        return jsonify({
+            'message': 'The user id should be a number!'
+        }), 400
+
+
 @blueprint.route('/products', methods=['POST'])
 @jwt_required
 @swag_from('docs/add_product.yml')

--- a/database/db.py
+++ b/database/db.py
@@ -14,11 +14,10 @@ class DatabaseConnection:
                 db = 'storemanager_db'
 
             self.connection = psycopg2.connect(
-                database='db6kf224t4p995',
-                user='xpeorndexusxeh',
-                password='2b2775c6cc4e00f879609dd2409078c2f61ba\
-5149ecece21070b5b3636a95c16',
-                host='ec2-54-83-49-109.compute-1.amazonaws.com'
+                database=db,
+                user='postgres',
+                password='##password',
+                host='localhost'
             )
 
             self.cursor = self.connection.cursor()


### PR DESCRIPTION
### What does this PR do?
It adds the API endpoint that enables an admin user to be able to promote another user.

### Description of the Task to be completed
The endpoint enables a user to pass the user id of the user they wish to promote to admin.

@Karuhanga @armstrongsouljah